### PR TITLE
Build for iOS and Android in CI, and deploy iOS builds to TestFlight

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,3 +35,22 @@ jobs:
         MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
         APP_STORE_CONNECT_KEY: ${{ secrets.APP_STORE_CONNECT_KEY }}
         COMMIT_MSG: ${{ github.event.commits[0].message }}
+  android:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: "android"
+      cancel-in-progress: true
+    steps:
+    - uses: actions/checkout@v4
+    - name: Use Node.js 20
+      uses: actions/setup-node@v4
+      with:
+        node-version: "20.x"
+        cache: "npm"
+    - run: npm ci
+    - name: Prebuild
+      run: npx expo prebuild
+    - name: Deploy to Play Store Testing
+      run: |
+        sudo gem install fastlane
+        fastlane android beta

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,7 +55,8 @@ jobs:
       with:
         java-version: '17'
         distribution: 'corretto'
-        cache: gradle
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@v4
     - name: Build (not currently deployed)
       run: |
         sudo gem install fastlane

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,6 +20,10 @@ jobs:
     - run: npm ci
     - name: Prebuild
       run: npx expo prebuild
+    - uses: irgaly/xcode-cache@v1
+      with:
+        key: xcode-cache-deriveddata-${{ github.workflow }}-${{ github.sha }}
+        restore-keys: xcode-cache-deriveddata-${{ github.workflow }}-
     - name: Deploy to TestFlight
       run: |
         brew install fastlane

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,7 +56,12 @@ jobs:
         java-version: '17'
         distribution: 'corretto'
         cache: gradle
-    - name: Deploy to Play Store Testing
+    - name: Build (not currently deployed)
       run: |
         sudo gem install fastlane
         fastlane android beta
+    - name: Send to Artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: outputs
+        path: android/app/build/outputs

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,33 @@
+name: Deploy
+
+on:
+  - push
+
+
+jobs:
+  ios:
+    runs-on: macos-14
+    concurrency:
+      group: "ios"
+      cancel-in-progress: true
+    steps:
+    - uses: actions/checkout@v4
+    - name: Use Node.js 20
+      uses: actions/setup-node@v4
+      with:
+        node-version: "20.x"
+        cache: "npm"
+    - run: npm ci
+    - name: Prebuild
+      run: npx expo prebuild
+    - name: Deploy to TestFlight
+      run: |
+        brew install fastlane
+        echo "$APP_STORE_CONNECT_KEY" > authkey.json
+        fastlane beta
+      env:
+        FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD: ${{ secrets.FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD }}
+        MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+        MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
+        APP_STORE_CONNECT_KEY: ${{ secrets.APP_STORE_CONNECT_KEY }}
+        COMMIT_MSG: ${{ github.event.commits[0].message }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,6 +50,12 @@ jobs:
     - run: npm ci
     - name: Prebuild
       run: npx expo prebuild
+    - name: Set up JDK
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'corretto'
+        cache: gradle
     - name: Deploy to Play Store Testing
       run: |
         sudo gem install fastlane

--- a/.gitignore
+++ b/.gitignore
@@ -6,8 +6,15 @@ node_modules/
 # Expo
 .expo/
 dist/
+ios/
+android/
 web-build/
 expo-env.d.ts
+
+# Fastlane
+fastlane/report.xml
+*.ipa
+*.dSYM.zip
 
 # Native
 *.orig.*

--- a/app.json
+++ b/app.json
@@ -14,7 +14,10 @@
     },
     "ios": {
       "supportsTablet": true,
-      "bundleIdentifier": "org.frcteam7525.reefscapescouting"
+      "bundleIdentifier": "org.frcteam7525.reefscapescouting",
+      "infoPlist": {
+        "ITSAppUsesNonExemptEncryption": false
+      }
     },
     "android": {
       "adaptiveIcon": {

--- a/app.json
+++ b/app.json
@@ -13,13 +13,15 @@
       "backgroundColor": "#ffffff"
     },
     "ios": {
-      "supportsTablet": true
+      "supportsTablet": true,
+      "bundleIdentifier": "org.frcteam7525.reefscapescouting"
     },
     "android": {
       "adaptiveIcon": {
         "foregroundImage": "./assets/adaptive-icon.png",
         "backgroundColor": "#ffffff"
-      }
+      },
+      "package": "org.frcteam7525.reefscapescouting"
     },
     "web": {
       "favicon": "./assets/favicon.png",

--- a/fastlane/Appfile
+++ b/fastlane/Appfile
@@ -1,0 +1,8 @@
+app_identifier("org.frcteam7525.reefscapescouting") # The bundle identifier of your app
+apple_id("avishkank@icloud.com") # Your Apple Developer Portal username
+
+itc_team_id("119038746") # App Store Connect Team ID
+team_id("FC733RM99L") # Developer Portal Team ID
+
+# For more information about the Appfile, see:
+#     https://docs.fastlane.tools/advanced/#appfile

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -33,6 +33,7 @@ platform :ios do
       build_configuration: "Release"
     )
     increment_build_number({
+      xcodeproj: XCODEPROJ,
       build_number: latest_testflight_build_number(api_key_path: API_KEY_PATH) + 1
     })
     build_app(workspace: "./ios/reefscapescouting.xcworkspace", scheme: "reefscapescouting")

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -46,7 +46,7 @@ platform :ios do
 end
 
 platform :android do
-  desc "Push a new internal release to Google Play"
+  desc "Build Android APK (currently not deployed)"
   lane :beta do
     setup_ci if ENV['CI']
     gradle(task: "assembleRelease", project_dir: "./android")

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -14,6 +14,7 @@ default_platform(:ios)
 
 XCODEPROJ = "./ios/reefscapescouting.xcodeproj".freeze
 SIGH_ENV_PREFIX = "sigh_org.frcteam7525.reefscapescouting_appstore".freeze
+API_KEY_PATH = "authkey.json".freeze
 
 platform :ios do
   desc "Push a new beta build to TestFlight"
@@ -31,10 +32,12 @@ platform :ios do
       profile: ENV["#{SIGH_ENV_PREFIX}_profile-path"],
       build_configuration: "Release"
     )
-    increment_build_number(xcodeproj: XCODEPROJ)
+    increment_build_number({
+      build_number: latest_testflight_build_number(api_key_path: API_KEY_PATH) + 1
+    })
     build_app(workspace: "./ios/reefscapescouting.xcworkspace", scheme: "reefscapescouting")
     upload_to_testflight(
-      api_key_path: "authkey.json",
+      api_key_path: API_KEY_PATH,
       skip_waiting_for_build_processing: true,
       changelog: "Upload from GitHub Actions, ref #{ENV['GITHUB_REF']}, sha #{ENV['GITHUB_SHA']}, msg #{ENV['COMMIT_MSG']}"
     )

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -44,3 +44,11 @@ platform :ios do
     )
   end
 end
+
+platform :android do
+  desc "Push a new internal release to Google Play"
+  lane :beta do
+    setup_ci if ENV['CI']
+    gradle(task: "assembleRelease", project_dir: "./android")
+  end
+end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,0 +1,42 @@
+# This file contains the fastlane.tools configuration
+# You can find the documentation at https://docs.fastlane.tools
+#
+# For a list of all available actions, check out
+#
+#     https://docs.fastlane.tools/actions
+#
+# For a list of all available plugins, check out
+#
+#     https://docs.fastlane.tools/plugins/available-plugins
+#
+
+default_platform(:ios)
+
+XCODEPROJ = "./ios/reefscapescouting.xcodeproj".freeze
+SIGH_ENV_PREFIX = "sigh_org.frcteam7525.reefscapescouting_appstore".freeze
+
+platform :ios do
+  desc "Push a new beta build to TestFlight"
+  lane :beta do
+    setup_ci if ENV['CI']
+    match(type: "appstore")
+    update_code_signing_settings(
+      path: XCODEPROJ,
+      use_automatic_signing: false,
+      team_id: ENV["#{SIGH_ENV_PREFIX}_team-id"],
+      code_sign_identity: ENV["#{SIGH_ENV_PREFIX}_certificate-name"]
+    )
+    update_project_provisioning(
+      xcodeproj: XCODEPROJ,
+      profile: ENV["#{SIGH_ENV_PREFIX}_profile-path"],
+      build_configuration: "Release"
+    )
+    increment_build_number(xcodeproj: XCODEPROJ)
+    build_app(workspace: "./ios/reefscapescouting.xcworkspace", scheme: "reefscapescouting")
+    upload_to_testflight(
+      api_key_path: "authkey.json",
+      skip_waiting_for_build_processing: true,
+      changelog: "Upload from GitHub Actions, ref #{ENV['GITHUB_REF']}, sha #{ENV['GITHUB_SHA']}, msg #{ENV['COMMIT_MSG']}"
+    )
+  end
+end

--- a/fastlane/Matchfile
+++ b/fastlane/Matchfile
@@ -1,0 +1,13 @@
+git_url("https://github.com/FRC-7525/iossign")
+
+storage_mode("git")
+
+type("development") # The default type, can be: appstore, adhoc, enterprise or development
+
+# app_identifier(["tools.fastlane.app", "tools.fastlane.app2"])
+# username("user@fastlane.tools") # Your Apple Developer Portal username
+
+# For all available options run `fastlane match --help`
+# Remove the # in the beginning of the line to enable the other options
+
+# The docs are available on https://docs.fastlane.tools/actions/match

--- a/fastlane/Matchfile
+++ b/fastlane/Matchfile
@@ -2,7 +2,7 @@ git_url("https://github.com/FRC-7525/iossign")
 
 storage_mode("git")
 
-type("development") # The default type, can be: appstore, adhoc, enterprise or development
+type("appstore") # The default type, can be: appstore, adhoc, enterprise or development
 
 # app_identifier(["tools.fastlane.app", "tools.fastlane.app2"])
 # username("user@fastlane.tools") # Your Apple Developer Portal username

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -1,0 +1,32 @@
+fastlane documentation
+----
+
+# Installation
+
+Make sure you have the latest version of the Xcode command line tools installed:
+
+```sh
+xcode-select --install
+```
+
+For _fastlane_ installation instructions, see [Installing _fastlane_](https://docs.fastlane.tools/#installing-fastlane)
+
+# Available Actions
+
+## iOS
+
+### ios beta
+
+```sh
+[bundle exec] fastlane ios beta
+```
+
+Push a new beta build to TestFlight
+
+----
+
+This README.md is auto-generated and will be re-generated every time [_fastlane_](https://fastlane.tools) is run.
+
+More information about _fastlane_ can be found on [fastlane.tools](https://fastlane.tools).
+
+The documentation of _fastlane_ can be found on [docs.fastlane.tools](https://docs.fastlane.tools).

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -25,6 +25,19 @@ Push a new beta build to TestFlight
 
 ----
 
+
+## Android
+
+### android beta
+
+```sh
+[bundle exec] fastlane android beta
+```
+
+Push a new internal release to Google Play
+
+----
+
 This README.md is auto-generated and will be re-generated every time [_fastlane_](https://fastlane.tools) is run.
 
 More information about _fastlane_ can be found on [fastlane.tools](https://fastlane.tools).

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "main": "expo-router/entry",
   "scripts": {
     "start": "expo start",
-    "android": "expo start --android",
-    "ios": "expo start --ios",
+    "android": "expo run:android",
+    "ios": "expo run:ios",
     "web": "expo start --web"
   },
   "dependencies": {


### PR DESCRIPTION
**iOS**

Building for iOS requires a paid Apple Developer account, and a bunch of identifiers and certificates. Setting all of this is up is extremely frustrating if you don't know what you're doing and y'all have much higher priority items to work on right now, so I went ahead and set it up. Here's how it works:

1. Use expo's `prebuild` to generate the `ios` project.
2. Use `fastlane match` to pull the correct certificates and provisioning profiles for signing the iOS app.
3. Build and sign the app, and deploy it to TestFlight. (See `Fastfile`)

This will allow you to instantly distribute the scouting app to up to 100 people (over email -- will give y'all access later). If the app passes Apple Beta review (which it might, it's not too hard), you can distribute it with a link, which is extremely convenient. 

**Android**

Since I already had `fastlane` set up, I set up a lane to build for Android and dump the APK into artifacts. Android distribution is way easier, so y'all can figure that out. I've used DeployGate in the past, and Firebase also has an App Distribution product that looks promising. If you want to use Google Play internal distribution, I have a paid account, so let me know and I can set it up.

----

Builds (and deploys for iOS) are automatically done on push. They're a little slow right now (~10 minutes), but it should hopefully be okay. Let me know if the speed is causing problems.